### PR TITLE
Allow loading of map links that define a rectangle, as well as numerous fixes

### DIFF
--- a/lich.rb
+++ b/lich.rb
@@ -1263,7 +1263,7 @@ class LimitedArray < Array
 end
 
 class XMLParser
-	attr_reader :mana, :max_mana, :health, :max_health, :spirit, :max_spirit, :last_spirit, :stamina, :max_stamina, :stance_text, :stance_value, :mind_text, :mind_value, :prepared_spell, :encumbrance_text, :encumbrance_full_text, :encumbrance_value, :indicator, :injuries, :injury_mode, :room_count, :room_title, :room_description, :room_exits, :room_exits_string, :familiar_room_title, :familiar_room_description, :familiar_room_exits, :bounty_task, :injury_mode, :server_time, :server_time_offset, :roundtime_end, :cast_roundtime_end, :last_pulse, :level, :next_level_value, :next_level_text, :society_task, :stow_container_id, :name, :game, :in_stream, :player_id, :active_spells, :prompt, :current_target_id
+	attr_reader :mana, :max_mana, :health, :max_health, :spirit, :max_spirit, :last_spirit, :stamina, :max_stamina, :stance_text, :stance_value, :mind_text, :mind_value, :prepared_spell, :encumbrance_text, :encumbrance_full_text, :encumbrance_value, :indicator, :injuries, :injury_mode, :room_count, :room_title, :room_description, :room_exits, :room_exits_string, :familiar_room_title, :familiar_room_description, :familiar_room_exits, :bounty_task, :injury_mode, :server_time, :server_time_offset, :roundtime_end, :cast_roundtime_end, :last_pulse, :level, :next_level_value, :next_level_text, :society_task, :stow_container_id, :name, :game, :in_stream, :current_output_class, :player_id, :active_spells, :prompt, :current_target_id
 	attr_accessor :send_fake_tags
 
 	@@warned_deprecated_spellfront = 0
@@ -1290,6 +1290,7 @@ class XMLParser
 		@pc = nil
 		@last_obj = nil
 		@in_stream = false
+		@current_output_class = nil
 		@player_status = nil
 		@fam_mode = String.new
 		@room_window_disabled = false
@@ -1402,6 +1403,8 @@ class XMLParser
 				@obj_name = nil
 				@obj_before_name = nil
 				@obj_after_name = nil
+			elsif name == 'output'
+				@current_output_class = attributes['class']
 			elsif name == 'dialogData' and attributes['id'] == 'ActiveSpells' and attributes['clear'] == 't'
 				@active_spells.clear
 			elsif name == 'resource' or name == 'nav'
@@ -5806,7 +5809,7 @@ def respond(first = "", *messages)
 		messages.flatten.each { |message| str += sprintf("%s\r\n", message.to_s.chomp) }
 		str.split(/\r?\n/).each { |line| Script.new_script_output(line); Buffer.update(line, Buffer::SCRIPT_OUTPUT) }
 		if $frontend == 'stormfront'
-			str = "<output class=\"mono\"/>\r\n#{str.gsub('&', '&amp;').gsub('<', '&lt;').gsub('>', '&gt;')}<output class=\"\"/>\r\n"
+			str = "<output class=\"mono\"/>\r\n#{str.gsub('&', '&amp;').gsub('<', '&lt;').gsub('>', '&gt;')}<output class=\"#{XMLData.current_output_class}\"/>\r\n"
 		elsif $frontend == 'profanity'
 			str = str.gsub('&', '&amp;').gsub('<', '&lt;').gsub('>', '&gt;')
 		end

--- a/lich.rb
+++ b/lich.rb
@@ -3883,6 +3883,7 @@ class Map
 							room['paths'] = Array.new
 							room['tags'] = Array.new
 							room['unique_loot'] = Array.new
+							room['links'] = Array.new
 						elsif element =~ /^(?:image|tsoran)$/ and attributes['name'] and attributes['x'] and attributes['y'] and attributes['size']
 							room['image'] = attributes['name']
 							room['image_coords'] = [ (attributes['x'].to_i - (attributes['size']/2.0).round), (attributes['y'].to_i - (attributes['size']/2.0).round), (attributes['x'].to_i + (attributes['size']/2.0).round), (attributes['y'].to_i + (attributes['size']/2.0).round) ]
@@ -3898,6 +3899,11 @@ class Map
 							room['tags'].push(text_string)
 						elsif current_tag =~ /^(?:title|description|paths|tag|unique_loot)$/
 							room[current_tag].push(text_string)
+						elsif current_tag == 'link'
+							dest_room_id = current_attributes['destination']
+							dest_map_name = current_attributes['mapName']
+							click_area = current_attributes['clickableArea'].split(',').collect { |num| num.to_i }
+							room['links'].push(Map::Link.new(dest_room_id, dest_map_name, click_area))
 						elsif current_tag == 'exit' and current_attributes['target']
 							if current_attributes['type'].downcase == 'string'
 								room['wayto'][current_attributes['target']] = text_string
@@ -3916,7 +3922,7 @@ class Map
 					tag_end = proc { |element|
 						if element == 'room'
 							room['unique_loot'] = nil if room['unique_loot'].empty?
-							Map.new(room['id'], room['title'], room['description'], room['paths'], room['location'], room['climate'], room['terrain'], room['wayto'], room['timeto'], room['image'], room['image_coords'], room['tags'], room['check_location'], room['unique_loot'], [])
+							Map.new(room['id'], room['title'], room['description'], room['paths'], room['location'], room['climate'], room['terrain'], room['wayto'], room['timeto'], room['image'], room['image_coords'], room['tags'], room['check_location'], room['unique_loot'], room['links'])
 						elsif element == 'map'
 							missing_end = false
 						end
@@ -4052,6 +4058,7 @@ class Map
 								file.write "		<exit target=\"#{target}\" type=\"#{room.wayto[target].class}\"#{cost}>#{room.wayto[target].gsub(/(<|>|"|'|&)/) { escape[$1] }}</exit>\n"
 							end
 						}
+						room.links.each { |link| file.write "		<link destination=\"#{link.destination_room_id}\" mapName=\"link.destination_map_name\" clickableArea=\"#{link.clickable_area.join(',')}\"/>\n" }
 						file.write "	</room>\n"
 					}
 					file.write "</map>\n"

--- a/lich.rb
+++ b/lich.rb
@@ -1442,6 +1442,7 @@ class XMLParser
 				if attributes['id'] == 'room objs'
 					GameObj.clear_loot
 					GameObj.clear_npcs
+					GameObj.clear_all_objs
 				elsif attributes['id'] == 'room players'
 					GameObj.clear_pcs
 				elsif attributes['id'] == 'room exits'
@@ -1735,6 +1736,8 @@ class XMLParser
 						end
 					elsif (text_string =~ /that (?:is|appears) ([\w\s]+)(?:,| and|\.)/) or (text_string =~ / \(([^\(]+)\)/)
 						GameObj.npcs[-1].status = $1
+					else
+						GameObj.new_all_obj(@obj_exist, @obj_noun, text_string)
 					end
 				elsif @active_ids.include?('room players')
 					if @active_tags.include?('a')
@@ -8852,6 +8855,7 @@ module Games
 			end
 		end
 		class GameObj
+			@@all_objs		= Array.new
 			@@loot          = Array.new
 			@@npcs          = Array.new
 			@@npc_status    = Hash.new
@@ -8932,14 +8936,14 @@ module Games
 			def GameObj.[](val)
 				if val.class == String
 					if val =~ /^\-?[0-9]+$/
-						obj = @@inv.find { |o| o.id == val } || @@loot.find { |o| o.id == val } || @@npcs.find { |o| o.id == val } || @@pcs.find { |o| o.id == val } || [ @@right_hand, @@left_hand ].find { |o| o.id == val } || @@room_desc.find { |o| o.id == val }
+						obj = @@inv.find { |o| o.id == val } || @@all_objs.find { |o| o.id == val } || @@loot.find { |o| o.id == val } || @@npcs.find { |o| o.id == val } || @@pcs.find { |o| o.id == val } || [ @@right_hand, @@left_hand ].find { |o| o.id == val } || @@room_desc.find { |o| o.id == val }
 					elsif val.split(' ').length == 1
-						obj = @@inv.find { |o| o.noun == val } || @@loot.find { |o| o.noun == val } || @@npcs.find { |o| o.noun == val } || @@pcs.find { |o| o.noun == val } || [ @@right_hand, @@left_hand ].find { |o| o.noun == val } || @@room_desc.find { |o| o.noun == val }
+						obj = @@inv.find { |o| o.noun == val } || @@all_objs.find { |o| o.noun == val } || @@loot.find { |o| o.noun == val } || @@npcs.find { |o| o.noun == val } || @@pcs.find { |o| o.noun == val } || [ @@right_hand, @@left_hand ].find { |o| o.noun == val } || @@room_desc.find { |o| o.noun == val }
 					else
-						obj = @@inv.find { |o| o.name == val } || @@loot.find { |o| o.name == val } || @@npcs.find { |o| o.name == val } || @@pcs.find { |o| o.name == val } || [ @@right_hand, @@left_hand ].find { |o| o.name == val } || @@room_desc.find { |o| o.name == val } || @@inv.find { |o| o.name =~ /\b#{Regexp.escape(val.strip)}$/i } || @@loot.find { |o| o.name =~ /\b#{Regexp.escape(val.strip)}$/i } || @@npcs.find { |o| o.name =~ /\b#{Regexp.escape(val.strip)}$/i } || @@pcs.find { |o| o.name =~ /\b#{Regexp.escape(val.strip)}$/i } || [ @@right_hand, @@left_hand ].find { |o| o.name =~ /\b#{Regexp.escape(val.strip)}$/i } || @@room_desc.find { |o| o.name =~ /\b#{Regexp.escape(val.strip)}$/i } || @@inv.find { |o| o.name =~ /\b#{Regexp.escape(val).sub(' ', ' .*')}$/i } || @@loot.find { |o| o.name =~ /\b#{Regexp.escape(val).sub(' ', ' .*')}$/i } || @@npcs.find { |o| o.name =~ /\b#{Regexp.escape(val).sub(' ', ' .*')}$/i } || @@pcs.find { |o| o.name =~ /\b#{Regexp.escape(val).sub(' ', ' .*')}$/i } || [ @@right_hand, @@left_hand ].find { |o| o.name =~ /\b#{Regexp.escape(val).sub(' ', ' .*')}$/i } || @@room_desc.find { |o| o.name =~ /\b#{Regexp.escape(val).sub(' ', ' .*')}$/i }
+						obj = @@inv.find { |o| o.name == val } || @@all_objs.find { |o| o.name == val }  || @@loot.find { |o| o.name == val } || @@npcs.find { |o| o.name == val } || @@pcs.find { |o| o.name == val } || [ @@right_hand, @@left_hand ].find { |o| o.name == val } || @@room_desc.find { |o| o.name == val } || @@inv.find { |o| o.name =~ /\b#{Regexp.escape(val.strip)}$/i } || @@loot.find { |o| o.name =~ /\b#{Regexp.escape(val.strip)}$/i } || @@npcs.find { |o| o.name =~ /\b#{Regexp.escape(val.strip)}$/i } || @@pcs.find { |o| o.name =~ /\b#{Regexp.escape(val.strip)}$/i } || [ @@right_hand, @@left_hand ].find { |o| o.name =~ /\b#{Regexp.escape(val.strip)}$/i } || @@room_desc.find { |o| o.name =~ /\b#{Regexp.escape(val.strip)}$/i } || @@inv.find { |o| o.name =~ /\b#{Regexp.escape(val).sub(' ', ' .*')}$/i } || @@loot.find { |o| o.name =~ /\b#{Regexp.escape(val).sub(' ', ' .*')}$/i } || @@npcs.find { |o| o.name =~ /\b#{Regexp.escape(val).sub(' ', ' .*')}$/i } || @@pcs.find { |o| o.name =~ /\b#{Regexp.escape(val).sub(' ', ' .*')}$/i } || [ @@right_hand, @@left_hand ].find { |o| o.name =~ /\b#{Regexp.escape(val).sub(' ', ' .*')}$/i } || @@room_desc.find { |o| o.name =~ /\b#{Regexp.escape(val).sub(' ', ' .*')}$/i }
 					end
 				elsif val.class == Regexp
-					obj = @@inv.find { |o| o.name =~ val } || @@loot.find { |o| o.name =~ val } || @@npcs.find { |o| o.name =~ val } || @@pcs.find { |o| o.name =~ val } || [ @@right_hand, @@left_hand ].find { |o| o.name =~ val } || @@room_desc.find { |o| o.name =~ val }
+					obj = @@inv.find { |o| o.name =~ val } || @@all_objs.find { |o| o.name =~ val }  || @@loot.find { |o| o.name =~ val } || @@npcs.find { |o| o.name =~ val } || @@pcs.find { |o| o.name =~ val } || [ @@right_hand, @@left_hand ].find { |o| o.name =~ val } || @@room_desc.find { |o| o.name =~ val }
 				end
 			end
 			def GameObj
@@ -8951,12 +8955,19 @@ module Games
 			def GameObj.new_npc(id, noun, name, status=nil)
 				obj = GameObj.new(id, noun, name)
 				@@npcs.push(obj)
+				@@all_objs.push(obj)
 				@@npc_status[id] = status
 				obj
 			end
 			def GameObj.new_loot(id, noun, name)
 				obj = GameObj.new(id, noun, name)
 				@@loot.push(obj)
+				@@all_objs.push(obj)
+				obj
+			end
+			def GameObj.new_all_obj(id, noun, name)
+				obj = GameObj.new(id, noun, name)
+				@@all_objs.push(obj)
 				obj
 			end
 			def GameObj.new_pc(id, noun, name, status=nil)
@@ -9011,6 +9022,9 @@ module Games
 			def GameObj.left_hand
 				@@left_hand.dup
 			end
+			def GameObj.clear_all_objs
+				@@all_objs.clear
+			end
 			def GameObj.clear_loot
 				@@loot.clear
 			end
@@ -9052,6 +9066,13 @@ module Games
 					nil
 				else
 					@@loot.dup
+				end
+			end
+			def GameObj.all_objs
+				if @@all_objs.empty?
+					nil
+				else
+					@@all_objs.dup
 				end
 			end
 			def GameObj.pcs

--- a/scripts/narost.lic
+++ b/scripts/narost.lic
@@ -602,8 +602,6 @@ Gtk.queue {
 		}
 	}
 
-	window.show_all
-
 	window_width = [window_width,100].max
 	window_height = [window_height,100].max
 	window.resize(window_width, window_height)
@@ -611,6 +609,8 @@ Gtk.queue {
 	window_position[0] = [[0, window_position[0].to_i].max, (Gdk.screen_width-window_width)].min
 	window_position[1] = [[0, window_position[1].to_i].max, (Gdk.screen_height-window_height)].min
 	window.move(window_position[0], window_position[1])
+
+	window.show_all
 
 	if trouble
 		respond

--- a/scripts/narost.lic
+++ b/scripts/narost.lic
@@ -37,6 +37,7 @@ if $SAFE > 0
 	exit
 end
 
+require 'set'
 trouble = script.vars.any? { |var| var =~ /trouble/i }
 
 Settings.load
@@ -235,11 +236,7 @@ no_room = proc {
 	}
 }
 
-find_clicked_link = proc { |click_x, click_y|
-	clicked_link = nil
-	map_name = current_map.slice(/([^\/\\]+)$/)
-	# fixme: use tags in map database for this
-	map_links = [
+gs_map_links = [
 		[ 'TI-teras.gif',                  1962, 2238,   68,  192, 'TI-wilds.gif',                   840, 1252 ],
 		[ 'TI-teras.gif',                   710,  972, 2130, 2260, 'WL-wehnimers.gif',              2338, 1070 ],
 		[ 'TI-wilds.gif',                  1124, 1412,  604,  682, 'TI-vtull.gif',                  2276, 1638 ],
@@ -296,6 +293,36 @@ find_clicked_link = proc { |click_x, click_y|
 		[ 'RR-citadel.gif',                1868, 2138, 1010, 1082, 'RR-riversrest.gif',             1598,  336 ],
 		[ 'VO-caravansary.gif',            1556, 1824, 1742, 1816, 'RR-riversrest.gif',              576, 1642 ],
 	]
+
+get_map_links = proc { |map_name|
+	if XMLData.game =~ /^(?:DRF|DR|DRPlat)$/
+		current_map_rooms = Map.list.find_all { |room| room.map_name == map_name }
+
+		links = []
+		current_map_rooms.each do |room|
+			room.links.each do |link|
+				linked_room = Map[link.destination_room_id]
+				item = [map_name,
+						link.clickable_area[0], link.clickable_area[2], #min/max X
+						link.clickable_area[1], link.clickable_area[3], #min/max Y
+						link.destination_map_name,
+						linked_room.map_x, linked_room.map_y # location to center in destination view
+					]
+				links.push(item)
+			end
+		end
+
+		links
+	else
+		gs_map_links
+	end
+}
+
+find_clicked_link = proc { |click_x, click_y|
+	clicked_link = nil
+	map_name = current_map.slice(/([^\/\\]+)$/)
+	# fixme: use tags in map database for this
+	map_links = get_map_links.call(map_name)
 	for link in map_links
 		if (link[0] =~ /#{map_name}/i) and (click_x > link[1]) and (click_x < link[2]) and (click_y > link[3]) and (click_y < link[4])
 			clicked_link = [ "#{map_dir}#{link[5]}", link[6], link[7] ]


### PR DESCRIPTION
narost.lic consumes these links and uses them to allow clicking within the UI to an adjoining map.

Also:
Fix for race condition with respond and XMLParser's in_stream.
Adding generalized collection of room objects due to not all all items being loot or NPCs
Maintain output class so that 'mono' formatting doesn't get messed up if a respond fires while it's printing