### PR TITLE
Sort 'Game Entry' list first by game, then by character 

### DIFF
--- a/lich.rb
+++ b/lich.rb
@@ -11016,6 +11016,8 @@ main_thread = Thread.new {
 							response = login_server.gets
 							if response =~ /^M\t/
 								liststore.clear
+								# Reset the sort order. Necessary for when the user connects, disconnects, and connects again
+  								liststore.set_sort_column_id(1, Gtk::SORT_ASCENDING)
 								for game in response.sub(/^M\t/, '').scan(/[^\t]+\t[^\t^\n]+/)
 									game_code, game_name = game.split("\t")
 									login_server.puts "N\t#{game_code}\n"

--- a/lich.rb
+++ b/lich.rb
@@ -10827,6 +10827,7 @@ main_thread = Thread.new {
 			login_button_box.pack_end(disconnect_button, false, false, 5)
 
 			liststore = Gtk::ListStore.new(String, String, String, String)
+			liststore.set_default_sort_func{|a,b| a[1] != b[1] ? a[1] <=> b[1] : a[3] <=> b[3]}
 			liststore.set_sort_column_id(1, Gtk::SORT_ASCENDING)
 
 			renderer = Gtk::CellRendererText.new
@@ -11037,6 +11038,8 @@ main_thread = Thread.new {
 										end
 									end
 								end
+								# Must come after the liststore is populated or records are lost.
+								liststore.set_sort_column_id(Gtk::TreeSortable::DEFAULT_SORT_COLUMN_ID)
 								disconnect_button.sensitive = true
 							else
 								login_server.close unless login_server.closed?


### PR DESCRIPTION
Same as prior (closed) pull request, but now fixed for when the user connects, disconnects, and connects again. It was the sequence, not the accounts, that were an issue.
