### PR TITLE
repository: update gameobj-data.xml ownership to elanthia-online

### DIFF
--- a/scripts/repository.lic
+++ b/scripts/repository.lic
@@ -116,6 +116,11 @@ if (XMLData.game =~ /^GS/) and Settings['first-gs-run']
 	Settings['updatable'][:scripts].push(:filename => 'gameobj-data.xml', :game => 'gs', :author => 'elanthia-online')
 end
 
+if s = Settings['updatable'][:scripts].find { |s| s[:filename] == 'gameobj-data.xml' && s[:author] == 'Tillmen' }
+  echo "updating ownership of gameobj-data.xml from Tillmen to elanthia-online"
+  s[:author] = 'elanthia-online'
+end
+
 require 'openssl'
 require 'digest/md5'
 

--- a/scripts/repository.lic
+++ b/scripts/repository.lic
@@ -113,7 +113,7 @@ if (XMLData.game =~ /^GS/) and Settings['first-gs-run']
 	Settings['first-gs-run'] = false
 	Settings['updatable'][:scripts].push(:filename => 'infomon.lic', :game => 'gs', :author => 'Tillmen')
 	Settings['updatable'][:scripts].push(:filename => 'spell-list.xml', :game => 'gs', :author => 'Tillmen')
-	Settings['updatable'][:scripts].push(:filename => 'gameobj-data.xml', :game => 'gs', :author => 'Tillmen')
+	Settings['updatable'][:scripts].push(:filename => 'gameobj-data.xml', :game => 'gs', :author => 'elanthia-online')
 end
 
 require 'openssl'


### PR DESCRIPTION
This update does two things to better handle the ownership handoff of gameobj-data.xml to elanthia-online:

1. Updates the author for gameobj-data.xml on first run to elanthia-online. I think it still makes sense to autoupdate this script out of the box and the autoupdate logic won't do anything with you as the author.

2. Updates the gameobj-data.xml author setting for existing installs to elanthia-online.