### PR TITLE
One character to force valid png file on Win10

### DIFF
--- a/lich.rb
+++ b/lich.rb
@@ -10530,7 +10530,7 @@ end
 
 if defined?(Gtk)
    unless File.exists?('fly64.png')
-      File.open('fly64.png', 'w') { |f| f.write '
+      File.open('fly64.png', 'wb') { |f| f.write '
          iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAMAAACdt4HsAAAChVBMVEUAAAAA
          AAABAQECAgIDAwMEBAQFBQUGBgYHBwcICAgKCgoLCwsMDAwNDQ0ODg4QEBAR
          ERESEhITExMUFBQWFhYXFxcYGBgZGRkaGhobGxscHBwdHR0eHh4fHx8hISEi


### PR DESCRIPTION
fly64.png on windows 10 platforms and Ruby 2.4 plus is not a valid png file (can't open it in any graphic editor).

Adding the 'binary' to 'write binary' forces a valid png file.

Tested back to ruby 2.0.0p648 (2015-12-16) [i386-mingw32]
Tested forward to ruby 2.4.5p335 (2018-10-18 revision 65137) [x64-mingw32]