### PR TITLE
adds incant? and incant= methods to Spell instances

### DIFF
--- a/lich.rb
+++ b/lich.rb
@@ -8190,6 +8190,12 @@ module Games
                false
             end
          end
+         def incant?
+           !@no_incant
+         end
+         def incant=(val)
+           @no_incant = !val
+         end
          def to_s
             @name.to_s
          end


### PR DESCRIPTION
This value is loaded from spell-list.xml, but there is no easy way to update the setting after that. As a workaround, many people are forking spell-list.xml to setting `incant="yes"` which is less than ideal and inflexible. Instead, we should be able to easily access and set this value from scripts during run time.

```
>;e echo Spell[410].incant?
[exec2: false]
>;e Spell[410].cast
[exec2]>prepare 410
You trace a simple rune while intoning the mystical phrase for Elemental Wave...
Your spell is ready.
[exec2]>cast 
You gesture.
A wave of dark ethereal ripples moves outward from you.
Cast Roundtime 3 Seconds.
(Forcing stance down to guarded)

>;e Spell[410].incant = true
>;e echo Spell[410].incant?
[exec2: true]
>;e Spell[410].cast
[exec2]>incant 410
You trace a simple rune while intoning the mystical phrase for Elemental Wave...
Your spell is ready.
You gesture at a jungle troll.
A wave of dark ethereal ripples moves outward from you.
A jungle troll is buffeted by the dark ethereal waves and is knocked to the ground.
Cast Roundtime 3 Seconds.

>;e echo Spell[410].incant = false
>;e echo Spell[410].incant?
[exec2: false]
>;e Spell[410].cast
[exec2]>prepare 410
You trace a simple rune while intoning the mystical phrase for Elemental Wave...
Your spell is ready.
[exec2]>cast 
You gesture.
A wave of dark ethereal ripples moves outward from you.
Cast Roundtime 3 Seconds.
```