### PR TITLE
Remove no incant option from 909 to fix self-cast version

### DIFF
--- a/data/spell-list.xml
+++ b/data/spell-list.xml
@@ -891,7 +891,7 @@
    <spell availability='all' name='Major Fire' number='908' stance='yes' type='attack'>
       <cost type='mana'>8</cost>
    </spell>
-   <spell availability='all' name='Tremors' number='909' type='attack/area/utility' incant='no'>
+   <spell availability='all' name='Tremors' number='909' type='attack/area/utility'>
       <duration span='refreshable' multicastable='no'>20 + Spells.wizard</duration>
       <cost type='mana'>9</cost>
       <message type='start'>Faint ripples in the (?:ground|dirt) form beneath you for a moment\.</message>


### PR DESCRIPTION
The self-cast evoked version of Tremors (909) is now used much more commonly than the active openly cast version. However, the existing configuration that disables incant makes it difficult to use through Lich especially with commonly used scripts like ;waggle and ;spellactive. This is particularly inconvenient when casting in town because the open version will get you in trouble with the justice system.