### PR TITLE
Fix go2 silvers check broken by Commageddon

### DIFF
--- a/scripts/go2.lic
+++ b/scripts/go2.lic
@@ -9,10 +9,12 @@
    original author: Shaelun
               game: any
               tags: core, movement
-           version: 1.25
+           version: 1.26
           required: Lich >= 4.6.14
 
    changelog:
+      1.26 (2020-10-08):
+        Fix silver check broken by Commageddon
       1.25 (2019-05-11):
         Fix DragonRealms auto drag feature (Sarvatt)
       1.24 (2019-03-03):
@@ -164,7 +166,7 @@ check_silvers = proc {
    hook_proc = proc { |server_string|
       if server_string =~ /^\s*Name\:|^\s*Gender\:|^\s*Normal \(Bonus\)|^\s*Strength \(STR\)\:|^\s*Constitution \(CON\)\:|^\s*Dexterity \(DEX\)\:|^\s*Agility \(AGI\)\:|^\s*Discipline \(DIS\)\:|^\s*Aura \(AUR\)\:|^\s*Logic \(LOG\)\:|^\s*Intuition \(INT\)\:|^\s*Wisdom \(WIS\)\:|^\s*Influence \(INF\)\:/
          nil
-      elsif server_string =~ /^\s*Mana\:\s+\-?[0-9]+\s+Silver\:\s+([0-9]+)/
+      elsif server_string =~ /^\s*Mana\:\s+\-?[0-9]+\s+Silver\:\s+([0-9,]+)/
          DownstreamHook.remove('go2_check_silvers')
          nil
       else
@@ -177,8 +179,8 @@ check_silvers = proc {
    put 'info'
    silence_me if undo_silence
    while (line = get)
-      if line =~ /^\s*Mana\:\s+\-?[0-9]+\s+Silver\:\s+([0-9]+)/
-         silvers = $1.to_i
+      if line =~ /^\s*Mana\:\s+\-?[0-9]+\s+Silver\:\s+([0-9,]+)/
+         silvers = $1.gsub(/,/,"").to_i
          break
       end
    end


### PR DESCRIPTION
The check_silvers proc was broken by the recent addition of commas to most numbers.  Currently go2 will report you are too poor even if you are carrying sufficient silvers.

```
Mana:  332   Silver: 2,500
>;go2 dais
--- Lich: go2 active.
>
[go2: You are too poor to make this trip.]
```

Verified this change fixes the issue:
```
Mana:  332   Silver: 2,500
>;go2 dais
--- Lich: go2 active.
>
[go2: ETA: 0:21:05 (614 rooms to move through)]
```
