### PR TITLE
infomon: handle enhanced stats with negative bonuses

### DIFF
--- a/scripts/infomon.lic
+++ b/scripts/infomon.lic
@@ -1136,7 +1136,7 @@ while line = get
 				Stats.exp = $3.to_i
 				Stats.level = $4.to_i
 				get
-				while get =~ /^\s*[A-Z][a-z]+\s\((STR|CON|DEX|AGI|DIS|AUR|LOG|INT|WIS|INF)\):\s+([0-9]+)\s\((\-?[0-9]+)\)\s+[.]{3}\s+(\d+)\s+\((\d+)\)/
+				while get =~ /^\s*[A-Z][a-z]+\s\((STR|CON|DEX|AGI|DIS|AUR|LOG|INT|WIS|INF)\):\s+([0-9]+)\s\((\-?[0-9]+)\)\s+[.]{3}\s+(\d+)\s+\((-?\d+)\)/
 					Stats.send("#{$1.downcase}=", [ $2.to_i, $3.to_i])
 					Stats.send("enhanced_#{$1.downcase}=", [ $4.to_i, $5.to_i]) rescue nil # available on Lich 4.6.54+
 				end


### PR DESCRIPTION
Without this change, infomon will never update the stat info (enhanced or unenhanced) if the enhanced version of a stat has a negative bonus. This is true in the very common case of an unenhanced stat with negative bonus as well.