### PR TITLE
Fix muckled? function.

### DIFF
--- a/lich.rb
+++ b/lich.rb
@@ -4619,12 +4619,12 @@ def checkreallybleeding
 end
 
 def muckled?
-   muckled = checkwebbed or checkdead or checkstunned
+   muckled = checkwebbed || checkdead || checkstunned
    if defined?(checksleeping)
-      muckled = muckled or checksleeping
+      muckled = muckled || checksleeping
    end
    if defined?(checkbound)
-      muckled = muckled or checkbound
+      muckled = muckled || checkbound
    end
    return muckled
 end


### PR DESCRIPTION
The muckled? function uses 'or' instead of '||'. This causes it, in effect, to only ever check for being webbed as the 'or' operator has lower precedence than the assignment operator. e.g. muckled = checkwebbed or checkdead... is reads as (muckled = checkwebbed) or checkdead... The rest isn't processed since muckled = checkwebbed succeeds.